### PR TITLE
Ignore "seen live" tag from lastfm

### DIFF
--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -140,7 +140,10 @@ def getartisttags(artist, bot):
     if 'tag' in tags['toptags']:
         for item in tags['toptags']['tag']:
             try:
-                tag_list.append(item['name'])
+                if not item['name'] == "seen live":
+                    tag_list.append(item['name'])
+                else:
+                    pass
             except KeyError:
                 pass
 


### PR DESCRIPTION
Every band is tagged as "seen live" by some user who doesn't properly understand what lastfm tags are for. It takes up a valuable slot that could be used for a more descriptive tag, so let's ignore it.
