### PR TITLE
Minor update to pie.json to fix typo

### DIFF
--- a/data/pie.json
+++ b/data/pie.json
@@ -87,7 +87,7 @@
 			"a gorgeous buttery crust",
 			"crispy crunchy bacon",
 			"a glass of unic0rn blood",
-			"a side of cripsy sweet potato fries",
+			"a side of crispy sweet potato fries",
 			"a picture of gonzobot stamped into the crust",
 			"a mystery sauce drizzled over the top",
 			"chunks of DavidLuizsHair",


### PR DESCRIPTION
Fixed typo. "cripsy" => "crispy"
