### PR TITLE
Update the hastebin server url

### DIFF
--- a/cloudbot/util/web.py
+++ b/cloudbot/util/web.py
@@ -22,7 +22,7 @@ import requests
 DEFAULT_SHORTENER = 'is.gd'
 DEFAULT_PASTEBIN = 'hastebin'
 
-HASTEBIN_SERVER = 'http://hastebin.com'
+HASTEBIN_SERVER = 'https://hastebin.com'
 
 # Python eval
 


### PR DESCRIPTION
Attempts to fix an issue where the `requests.post()` call to post the data may return a normal html page rather than the expected JSON response. This is due to hastebin rewriting the http:// url improperly.