### PR TITLE
fixed inconsistent behaviour with -global and global in karma.py

### DIFF
--- a/plugins/karma.py
+++ b/plugins/karma.py
@@ -103,7 +103,7 @@ def points(text, chan, db, conn):
     score = 0
     karma = ""
     thing = ""
-    if text.endswith("-global"):
+    if text.endswith("-global") or text.endswith(" global"):
         thing = text[:-7].strip()
         karma = db.execute("select score from karma where thing = :thing", {'thing': thing.lower()}).fetchall()
     else:
@@ -132,7 +132,7 @@ def pointstop(text, chan, db, message, conn, notice):
     points = defaultdict(int)
     items = ""
     out = ""
-    if text == "global":
+    if text == "global" or text == "-global":
         items = db.execute("select thing, score from karma").fetchall()
         out = "The top {} favorite things in all channels are: "
     else:
@@ -162,7 +162,7 @@ def pointsbottom(text, chan, db, message, conn, notice):
     points = defaultdict(int)
     items = ""
     out = ""
-    if text == "global":
+    if text == "global" or text == "-global":
         items = db.execute("select thing, score from karma").fetchall()
         out = "The {} most hated things in all channels are: "
     else:


### PR DESCRIPTION
Changed .points, .topten and .bottomten to accept both "global" and "-global"
Previously, .points would only accept "-global" and .top/bottomten would only accept "global"