### PR TITLE
Fix core_tracker.py tracking of bot joins/parts

### DIFF
--- a/cloudbot/clients/irc.py
+++ b/cloudbot/clients/irc.py
@@ -393,6 +393,8 @@ class _IrcProtocol(asyncio.Protocol):
 
             if channel:
                 channel = channel.lower()
+                if channel[0] == ':':
+                    channel = channel[1:].split()[0]  # Just in case there is more data
                 if channel == self.conn.nick.lower():
                     channel = nick.lower()
 

--- a/plugins/core_tracker.py
+++ b/plugins/core_tracker.py
@@ -69,23 +69,23 @@ def on_nick(irc_paramlist, conn, irc_raw):
 # mostly when using a BNC which saves channels
 @asyncio.coroutine
 @hook.irc_raw("JOIN")
-def on_join(conn, chan, target):
+def on_join(conn, chan, nick):
     """
     :type conn: cloudbot.client.Client
     :type chan: str
     :type nick: str
     """
-    if target == conn.nick:
+    if nick == conn.nick:
         bot_joined_channel(conn, chan)
 
 
 @asyncio.coroutine
 @hook.irc_raw("PART")
-def on_join(conn, chan, target):
+def on_part(conn, chan, nick):
     """
     :type conn: cloudbot.client.Client
     :type chan: str
     :type nick: str
     """
-    if target == conn.nick:
-        bot_joined_channel(conn, chan)
+    if nick == conn.nick:
+        bot_left_channel(conn, chan)


### PR DESCRIPTION
This fixes 2 issues:
-core_tracker.py was calling bot_joined_channel() on part and was checking the target of join/part messages instead of the nick
-The core parser was not grabbing the channel from JOIN messages in certain cases
This also makes sure the channel parameter is set properly on INVITE messages, as the channel will be the second parameter