### PR TITLE
gnomesagainsthumanity.py exploit fix

### DIFF
--- a/plugins/gnomeagainsthumanity.py
+++ b/plugins/gnomeagainsthumanity.py
@@ -15,12 +15,12 @@ def shuffle_deck(bot):
         gnomecards = json.load(f)
 
 
-        
+
 @hook.command('cah')
 def CAHwhitecard(text, message):
     '''Submit text to be used as a CAH whitecard'''
     CardText = text.strip()
-    message(random.choice(gnomecards['black']).format(text))
+    return random.choice(gnomecards['black']).format(text)
 
 
 @hook.command('cahb')
@@ -32,4 +32,4 @@ def CAHblackcard(text, message):
         return random.choice(gnomecards['white'])
 
     out = re.sub(r'_', blankfiller, CardText)
-    message(out)
+    return out

--- a/plugins/gnomeagainsthumanity.py
+++ b/plugins/gnomeagainsthumanity.py
@@ -31,5 +31,5 @@ def CAHblackcard(text, message):
     def blankfiller(matchobj):
         return random.choice(gnomecards['white'])
 
-    out = re.sub(r'_', blankfiller, CardText)
+    out = re.sub(r'\b_\b', blankfiller, CardText)
     return out


### PR DESCRIPTION
The .cahb command allows any user to provide an exact message for gonzobot and gonzobot does not prepend the nick, allowing possible exploits with other bots or network services.