### PR TITLE
Fix + general cleanup for hookup.py

### DIFF
--- a/data/bite.json
+++ b/data/bite.json
@@ -1,0 +1,35 @@
+{
+    "templates": [
+        "{action} {user}'s {bodypart}"
+    ],
+    "parts": {
+        "action": [
+            "bites",
+            "nips",
+            "nibbles",
+            "chomps",
+            "licks",
+            "teases",
+            "chews",
+            "gums",
+            "tastes"
+        ],
+        "bodypart": [
+            "cheeks",
+            "ear lobes",
+            "nipples",
+            "nose",
+            "neck",
+            "toes",
+            "fingers",
+            "butt",
+            "taint",
+            "thigh",
+            "grundle",
+            "tongue",
+            "calf",
+            "nurses",
+            "nape"
+        ]
+    }
+}

--- a/data/glomp.txt
+++ b/data/glomp.txt
@@ -1,0 +1,6 @@
+glomps
+tackles
+tackle hugs
+sexually glomps
+takes a flying leap and glomps
+bear hugs

--- a/data/hookup.json
+++ b/data/hookup.json
@@ -1,0 +1,48 @@
+{
+    "templates": [
+        "{user1} used {weapon} and did it with {user2} in the {room}."
+    ],
+    "parts": {
+        "weapon": [
+            "a candlestick",
+            "an axe",
+            "a pistol",
+            "rope",
+            "gloves",
+            "a horseshoe",
+            "a knife",
+            "a baseball bat",
+            "a chalice",
+            "a dumbbell",
+            "a wrench",
+            "a trophy",
+            "a pipe",
+            "garden shears"
+        ],
+        "room": [
+            "courtyard",
+            "guest house",
+            "observatory",
+            "theatre",
+            "drawing room",
+            "garage",
+            "spa",
+            "master bedroom",
+            "studio",
+            "pool",
+            "arcade",
+            "beach house",
+            "surf shop",
+            "kitchen",
+            "ballroom",
+            "conservatory",
+            "billiard room",
+            "library",
+            "study",
+            "hallway",
+            "lounge",
+            "dining room",
+            "cellar"
+        ]
+    }
+}

--- a/plugins/hookup.py
+++ b/plugins/hookup.py
@@ -1,18 +1,14 @@
 import codecs
 import json
+import os
 import random
 import time
-
-import os
 
 from cloudbot import hook
 from cloudbot.util.textgen import TextGenerator
 
 hookups = {}
-
-bitesyns = ["bites", "nips", "nibbles", "chomps", "licks", "teases", "chews", "gums", "tastes"]
-bodyparts = ["cheeks", "ear lobes", "nipples", "nose", "neck", "toes", "fingers", "butt", "taint", "thigh", "grundle", "tongue", "calf", "nurses", "nape"]
-
+bites = {}
 glomps = []
 
 
@@ -20,6 +16,7 @@ glomps = []
 def load_data(bot):
     hookups.clear()
     glomps.clear()
+    bites.clear()
 
     with codecs.open(os.path.join(bot.data_dir, "hookup.json"), encoding="utf-8") as f:
         hookups.update(json.load(f))
@@ -27,6 +24,9 @@ def load_data(bot):
     with codecs.open(os.path.join(bot.data_dir, "glomp.txt"), encoding="utf-8") as f:
         lines = (line.strip() for line in f if not line.startswith("//"))
         glomps.extend(filter(None, lines))
+
+    with codecs.open(os.path.join(bot.data_dir, "bite.json"), encoding="utf-8") as f:
+        bites.update(json.load(f))
 
 
 @hook.command(autohelp=False)
@@ -54,10 +54,8 @@ def bite(text, chan, action):
     if not text:
         return "please tell me who to bite."
     name = text.split(' ')[0]
-    bite = random.choice(bitesyns)
-    body = random.choice(bodyparts)
-    out = "{} {}'s {}.".format(bite, name, body)
-    action(out, chan)
+    generator = TextGenerator(bites['templates'], bites['parts'], variables={'user': name})
+    action(generator.generate_string(), chan)
 
 
 @hook.command(autohelp=False)

--- a/plugins/hookup.py
+++ b/plugins/hookup.py
@@ -12,24 +12,21 @@ bodyparts = ["cheeks", "ear lobes", "nipples", "nose", "neck", "toes", "fingers"
 glomps = ["glomps", "tackles", "tackle hugs", "sexually glomps", "takes a flying leap and glomps", "bear hugs"]
 
 usrcache = []
-#glob_chan = chan
 
-#@hook.command(autohelp=False)
+@hook.command(autohelp=False)
 def hookup(db, conn, chan):
     """matches two users from the channel in a sultry scene."""
     times = time.time() - 86400
-    people = db.execute("select name from seen_user where chan = :chan and time > :time", {"chan": chan, "time": times}).fetchall()
-    if not people:
+    results = db.execute("select name from seen_user where chan = :chan and time > :time", {"chan": chan, "time": times}).fetchall()
+    if not results or len(results) < 2:
         return "something went wrong"
-    person1 = people[random.randint(0,len(people) - 1)]
-    person2 = people[random.randint(0,len(people) - 1)]
-    loop = 0
-    while person1 == person2 or loop < 5:
-        person2 = people[random.randint(0, len(people) -1 )]
-        loop = loop + 2
+    # Make sure the list of people is unique
+    people = list(set(row[0] for row in results))
+    random.shuffle(people)
+    person1, person2 = people[:2]
     room = random.choice(rooms)
     weapon = random.choice(weapons)
-    out = "{} used {} and did it with {} in the {}.".format(person1[0], weapon, person2[0], room)
+    out = "{} used {} and did it with {} in the {}.".format(person1, weapon, person2, room)
     return out
 
 @hook.command(autohelp=False)

--- a/plugins/hookup.py
+++ b/plugins/hookup.py
@@ -13,16 +13,20 @@ hookups = {}
 bitesyns = ["bites", "nips", "nibbles", "chomps", "licks", "teases", "chews", "gums", "tastes"]
 bodyparts = ["cheeks", "ear lobes", "nipples", "nose", "neck", "toes", "fingers", "butt", "taint", "thigh", "grundle", "tongue", "calf", "nurses", "nape"]
 
-glomps = ["glomps", "tackles", "tackle hugs", "sexually glomps", "takes a flying leap and glomps", "bear hugs"]
-
-usrcache = []
+glomps = []
 
 
 @hook.on_start
-def load_hookups(bot):
+def load_data(bot):
     hookups.clear()
+    glomps.clear()
+
     with codecs.open(os.path.join(bot.data_dir, "hookup.json"), encoding="utf-8") as f:
         hookups.update(json.load(f))
+
+    with codecs.open(os.path.join(bot.data_dir, "glomp.txt"), encoding="utf-8") as f:
+        lines = (line.strip() for line in f if not line.startswith("//"))
+        glomps.extend(filter(None, lines))
 
 
 @hook.command(autohelp=False)


### PR DESCRIPTION
- Removes the need for a loop by selecting unique elements from a shuffled set
- Moves the .hookup, .bite, and .glomp data to files in the data/ directory

A more finalized version of #114 