### PR TITLE
Make sure to always send /mode when joining a channel

### DIFF
--- a/plugins/admin_bot.py
+++ b/plugins/admin_bot.py
@@ -251,10 +251,8 @@ def join(text, conn, nick, message, notice):
             target = "#{}".format(target)
         if logchannel:
             message("{} used JOIN to make me join {}.".format(nick, target), logchannel)
-        mode = "mode {}".format(target)
         notice("Attempting to join {}...".format(target))
         conn.join(target)
-        conn.send(mode)
 
 
 @asyncio.coroutine

--- a/plugins/core_misc.py
+++ b/plugins/core_misc.py
@@ -16,9 +16,13 @@ def invite(irc_paramlist, conn):
     """
     invite_join = conn.config.get('invite_join', True)
     if invite_join:
-        mode = "mode {}".format(irc_paramlist[-1])
-        conn.send(mode)
         conn.join(irc_paramlist[-1])
+
+
+@hook.irc_raw('JOIN')
+def on_join(chan, conn):
+    conn.cmd("MODE", chan)
+
 
 @hook.irc_raw('324')
 def check_mode(irc_paramlist, conn, message):
@@ -29,7 +33,7 @@ def check_mode(irc_paramlist, conn, message):
         message("I do not stay in unregistered channels", irc_paramlist[1])
         out = "PART {}".format(irc_paramlist[1])
         conn.send(out)
-        
+
 
 # Identify to NickServ (or other service)
 @asyncio.coroutine
@@ -77,9 +81,6 @@ def onjoin(conn, bot):
     for channel in conn.channels:
         conn.join(channel)
         yield from asyncio.sleep(0.4)
-        if conn.name == "snoonet":
-            mode = "mode {}".format(channel)
-            conn.send(mode)
 
     conn.ready = True
     bot.logger.info("[{}|misc] Bot has finished sending join commands for network.".format(conn.name))


### PR DESCRIPTION
This moves the sending of `MODE #chan` when joining a channel to when the bot receives the `JOIN` command from the server