### PR TITLE
spotify_url will now show the URI in addition to the URL

### DIFF
--- a/plugins/spotify.py
+++ b/plugins/spotify.py
@@ -112,14 +112,15 @@ def spotify_url(bot, match):
         artist = data["artists"][0]["name"]
         album = data["album"]["name"]
         url = data['external_urls']['spotify']
+        uri = data['uri']
 
-        return "Spotify Track: \x02{}\x02 by \x02{}\x02 from the album \x02{}\x02 {}".format(
-            name, artist, album, url)
+        return "Spotify Track: \x02{}\x02 by \x02{}\x02 from the album \x02{}\x02 {} [{}]".format(
+            name, artist, album, url, uri)
     elif _type == "artist":
         return "Spotify Artist: \x02{}\x02, followers: \x02{}\x02, genres: \x02{}\x02".format(
             data["name"], data["followers"]["total"],
             ', '.join(data["genres"]))
     elif _type == "album":
-        return "Spotify Album: \x02{}\x02 - \x02{}\x02 {}".format(
+        return "Spotify Album: \x02{}\x02 - \x02{}\x02 {} [{}]".format(
             data["artists"][0]["name"], data["name"],
-            data['external_urls']['spotify'])
+            data['external_urls']['spotify'], data['uri'])


### PR DESCRIPTION
Showing the URI makes it easier for people not wanting to play/view the track/album in the Spotify web player. The URI will open Spotify itself.

This changes:

    Spotify Album: ２８１４ - Rain Temple https://open.spotify.com/album/18EtfdFj2SRKkK7Uy3u2yC

to

    Spotify Album: ２８１４ - Rain Temple https://open.spotify.com/album/18EtfdFj2SRKkK7Uy3u2yC [spotify:album:18EtfdFj2SRKkK7Uy3u2yC]
  
Same goes for the tracks. This has been tested manually.