### PR TITLE
Add a check for blank or entirely whitespace strings.

### DIFF
--- a/plugins/correction.py
+++ b/plugins/correction.py
@@ -19,6 +19,9 @@ def correction(match, conn, nick, chan, message):
     replace = groups[1]
     if find == replace:
         return "really dude? you want me to replace {} with {}?".format(find, replace)
+    
+    if not find.strip(): # Replacing empty or entirely whitespace strings is spammy
+        return "really dude? you want me to replace nothing with {}?".format(replace)
 
     for item in conn.history[chan].__reversed__():
         name, timestamp, msg = item


### PR DESCRIPTION
Allowing users to correct blank or whitespace strings results in a lot of spam.

Previously this would show:

       <user1> The quick brown fox jumps over the lazy dog.
       <user2> s/ /hello
    <cloudbot> Correction, <user1> Thehelloquickhellobrownhellofoxhellojumpshellooverhellothehellolazyhellodog.

Now this should show:

       <user1> The quick brown fox jumps over the lazy dog.
       <user2> s/ /hello
    <cloudbot> really dude? you want me to replace nothing with hello?