### PR TITLE
Handle +r mode changes

### DIFF
--- a/plugins/core_misc.py
+++ b/plugins/core_misc.py
@@ -36,6 +36,26 @@ def check_mode(irc_paramlist, conn, message):
         conn.send(out)
 
 
+@hook.irc_raw('MODE')
+def on_mode_change(conn, irc_paramlist, message):
+    require_reg = conn.config.get('require_registered_channels', False)
+    chan = irc_paramlist[0]
+    modes = irc_paramlist[1]
+    new_modes = {}
+    adding = True
+    for c in modes:
+        if c == '+':
+            adding = True
+        elif c == '-':
+            adding = False
+        else:
+            new_modes[c] = adding
+
+    if chan[0] == '#' and require_reg and not new_modes.get("r", True):
+        message("I do not stay in unregistered channels", chan)
+        conn.part(chan)
+
+
 # Identify to NickServ (or other service)
 @asyncio.coroutine
 @hook.irc_raw('004')


### PR DESCRIPTION
This makes sure gonzobot will leave a channel when +r (registered) is unset