### PR TITLE
Fix various DeprecationWarnings in the core and plugins

### DIFF
--- a/cloudbot/__main__.py
+++ b/cloudbot/__main__.py
@@ -6,6 +6,10 @@ import time
 import signal
 
 # store the original working directory, for use when restarting
+from functools import partial
+
+from cloudbot.util import async_util
+
 original_wd = os.path.realpath(".")
 
 # set up environment - we need to make sure we are in the install directory
@@ -47,7 +51,8 @@ def main():
             stopped_while_restarting = True
         else:
             _bot.loop.call_soon_threadsafe(
-                lambda: asyncio.async(_bot.stop("Killed (Received SIGINT {})".format(signum)), loop=_bot.loop))
+                partial(async_util.wrap_future, _bot.stop("Killed (Received SIGINT {})".format(signum)), loop=_bot.loop)
+            )
 
         logger.warning("Bot received Signal Interrupt ({})".format(signum))
 

--- a/cloudbot/__main__.py
+++ b/cloudbot/__main__.py
@@ -49,7 +49,7 @@ def main():
             _bot.loop.call_soon_threadsafe(
                 lambda: asyncio.async(_bot.stop("Killed (Received SIGINT {})".format(signum)), loop=_bot.loop))
 
-        logger.warn("Bot received Signal Interrupt ({})".format(signum))
+        logger.warning("Bot received Signal Interrupt ({})".format(signum))
 
         # restore the original handler so if they do it again it triggers
         signal.signal(signal.SIGINT, original_sigint)

--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -327,13 +327,20 @@ class Event:
     if sys.version_info < (3, 7, 0):
         # noinspection PyCompatibility
         @asyncio.coroutine
-        def async(self, function, *args, **kwargs):
+        def async_(self, function, *args, **kwargs):
             warnings.warn(
                 "event.async() is deprecated, use event.async_call() instead.",
                 DeprecationWarning, stacklevel=2
             )
             result = yield from self.async_call(function, *args, **kwargs)
             return result
+
+
+# Silence deprecation warnings about use of the 'async' name as a function
+try:
+    setattr(Event, 'async', getattr(Event, 'async_'))
+except AttributeError:
+    pass
 
 
 class CommandEvent(Event):

--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -157,7 +157,7 @@ class Event:
             # we're running a coroutine hook with a db, so initialise an executor pool
             self.db_executor = concurrent.futures.ThreadPoolExecutor(1)
             # be sure to initialize the db in the database executor, so it will be accessible in that thread.
-            self.db = yield from self.async(self.bot.db_session)
+            self.db = yield from self.async_call(self.bot.db_session)
 
     def prepare_threaded(self):
         """
@@ -193,7 +193,7 @@ class Event:
         if self.db is not None:
             #logger.debug("Closing database session for {}:threaded=False".format(self.hook.description))
             # be sure the close the database in the database executor, as it is only accessable in that one thread
-            yield from self.async(self.db.close)
+            yield from self.async_call(self.db.close)
             self.db = None
 
     def close_threaded(self):

--- a/cloudbot/hook.py
+++ b/cloudbot/hook.py
@@ -309,7 +309,7 @@ def sieve(param=None, **kwargs):
     """
 
     def _sieve_hook(func):
-        assert len(inspect.getargspec(func).args) == 3, \
+        assert len(inspect.getfullargspec(func).args) == 3, \
             "Sieve plugin has incorrect argument count. Needs params: bot, input, plugin"
 
         hook = _get_hook(func, "sieve")

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -5,11 +5,13 @@ import inspect
 import logging
 import os
 import re
+import warnings
 from collections import defaultdict
 from operator import attrgetter
 from itertools import chain
 
 import sqlalchemy
+import sys
 
 from cloudbot.event import Event
 from cloudbot.hook import Priority, Action
@@ -644,6 +646,13 @@ class Hook:
 
         # don't process args starting with "_"
         self.required_args = [arg for arg in sig.parameters.keys() if not arg.startswith('_')]
+        if sys.version_info < (3, 7, 0):
+            if "async" in self.required_args:
+                logger.warning("Use of deprecated function 'async' in %s", self.description)
+                warnings.warn(
+                    "event.async() is deprecated, use event.async_call() instead.",
+                    DeprecationWarning, stacklevel=2
+                )
 
         if asyncio.iscoroutine(self.function) or asyncio.iscoroutinefunction(self.function):
             self.threaded = False

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -17,7 +17,7 @@ import time
 
 from cloudbot.event import Event
 from cloudbot.hook import Priority, Action
-from cloudbot.util import database
+from cloudbot.util import database, async_util
 
 logger = logging.getLogger("cloudbot")
 
@@ -204,7 +204,7 @@ class PluginManager:
             self._log_hook(on_cap_ack_hook)
 
         for periodic_hook in plugin.periodic:
-            task = asyncio.async(self._start_periodic(periodic_hook))
+            task = async_util.wrap_future(self._start_periodic(periodic_hook))
             plugin.tasks.append(task)
             self._log_hook(periodic_hook)
 

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -13,6 +13,8 @@ from itertools import chain
 import sqlalchemy
 import sys
 
+import time
+
 from cloudbot.event import Event
 from cloudbot.hook import Priority, Action
 from cloudbot.util import database
@@ -649,6 +651,7 @@ class Hook:
         if sys.version_info < (3, 7, 0):
             if "async" in self.required_args:
                 logger.warning("Use of deprecated function 'async' in %s", self.description)
+                time.sleep(1)
                 warnings.warn(
                     "event.async() is deprecated, use event.async_call() instead.",
                     DeprecationWarning, stacklevel=2

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -640,12 +640,10 @@ class Hook:
         self.function = func_hook.function
         self.function_name = self.function.__name__
 
-        self.required_args = inspect.getargspec(self.function)[0]
-        if self.required_args is None:
-            self.required_args = []
+        sig = inspect.signature(self.function)
 
         # don't process args starting with "_"
-        self.required_args = [arg for arg in self.required_args if not arg.startswith("_")]
+        self.required_args = [arg for arg in sig.parameters.keys() if not arg.startswith('_')]
 
         if asyncio.iscoroutine(self.function) or asyncio.iscoroutinefunction(self.function):
             self.threaded = False

--- a/cloudbot/reloader.py
+++ b/cloudbot/reloader.py
@@ -1,8 +1,11 @@
 import asyncio
 import os.path
+from functools import partial
 
 from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
+
+from cloudbot.util import async_util
 
 
 class PluginReloader(object):
@@ -38,7 +41,8 @@ class PluginReloader(object):
 
         if isinstance(path, bytes):
             path = path.decode()
-        self.bot.loop.call_soon_threadsafe(lambda: asyncio.async(self._reload(path), loop=self.bot.loop))
+
+        self.bot.loop.call_soon_threadsafe(partial(async_util.wrap_future, self._reload(path), loop=self.bot.loop))
 
     def unload(self, path):
         """
@@ -48,7 +52,8 @@ class PluginReloader(object):
         """
         if isinstance(path, bytes):
             path = path.decode()
-        self.bot.loop.call_soon_threadsafe(lambda: asyncio.async(self._unload(path), loop=self.bot.loop))
+
+        self.bot.loop.call_soon_threadsafe(partial(async_util.wrap_future, self._unload(path), loop=self.bot.loop))
 
     @asyncio.coroutine
     def _reload(self, path):

--- a/cloudbot/util/async_util.py
+++ b/cloudbot/util/async_util.py
@@ -1,0 +1,20 @@
+"""
+Wraps various asyncio functions
+"""
+
+import asyncio
+
+import sys
+
+
+def wrap_future(fut, *, loop=None):
+    """
+    Wraps asyncio.async()/asyncio.ensure_future() depending on the python version
+    :param fut: The awaitable, future, or coroutine to wrap
+    :param loop: The loop to run in
+    :return: The wrapped future
+    """
+    if sys.version_info < (3, 4, 4):
+        return asyncio.async(fut, loop=loop)
+
+    return asyncio.ensure_future(fut, loop=loop)

--- a/plugins/autojoin.py
+++ b/plugins/autojoin.py
@@ -21,8 +21,8 @@ def get_channels(db, conn):
 
 @asyncio.coroutine
 @hook.irc_raw('004')
-def do_joins(db, conn, async):
-    chans = yield from async(get_channels, db, conn)
+def do_joins(db, conn, async_call):
+    chans = yield from async_call(get_channels, db, conn)
     join_throttle = conn.config.get("join_throttle", 0.4)
     for chan in chans:
         conn.join(chan[1])

--- a/plugins/geoip.py
+++ b/plugins/geoip.py
@@ -10,6 +10,7 @@ import geoip2.database
 import geoip2.errors
 
 from cloudbot import hook
+from cloudbot.util import async_util
 
 logger = logging.getLogger("cloudbot")
 
@@ -52,6 +53,7 @@ def update_db():
         return geoip2.database.Reader(PATH)
 
 
+@asyncio.coroutine
 def check_db(loop):
     """
     runs update_db in an executor thread and sets geoip_reader to the result
@@ -68,7 +70,7 @@ def check_db(loop):
 @asyncio.coroutine
 @hook.on_start
 def load_geoip(loop):
-    asyncio.async(check_db(loop), loop=loop)
+    async_util.wrap_future(check_db(loop), loop=loop)
 
 
 @asyncio.coroutine

--- a/plugins/log.py
+++ b/plugins/log.py
@@ -1,16 +1,15 @@
 import asyncio
-import os
 import codecs
+import os
 import time
 
 import cloudbot
 from cloudbot import hook
 from cloudbot.event import EventType
-
-
 # +---------+
 # | Formats |
 # +---------+
+from cloudbot.hook import Priority
 from cloudbot.util.formatting import strip_colors
 
 base_formats = {
@@ -253,3 +252,11 @@ def flush_log():
         stream.flush()
     for name, stream in raw_cache.values():
         stream.flush()
+
+
+@hook.on_stop(priority=Priority.LOWEST)
+def close_logs():
+    for name, stream in stream_cache.values():
+        stream.close()
+    for name, stream in raw_cache.values():
+        stream.close()

--- a/plugins/log.py
+++ b/plugins/log.py
@@ -245,7 +245,6 @@ def console_log(bot, event):
         bot.logger.info(text)
 
 
-@hook.on_stop
 @hook.command("flushlog", permissions=["botcontrol"])
 def flush_log():
     for name, stream in stream_cache.values():
@@ -254,9 +253,12 @@ def flush_log():
         stream.flush()
 
 
-@hook.on_stop(priority=Priority.LOWEST)
+@hook.on_stop
 def close_logs():
     for name, stream in stream_cache.values():
+        stream.flush()
         stream.close()
+
     for name, stream in raw_cache.values():
+        stream.flush()
         stream.close()

--- a/plugins/remind.py
+++ b/plugins/remind.py
@@ -40,26 +40,26 @@ table = Table(
 
 
 @asyncio.coroutine
-def delete_reminder(async, db, network, remind_time, user):
+def delete_reminder(async_call, db, network, remind_time, user):
     query = table.delete() \
         .where(table.c.network == network.lower()) \
         .where(table.c.remind_time == remind_time) \
         .where(table.c.added_user == user.lower())
-    yield from async(db.execute, query)
-    yield from async(db.commit)
+    yield from async_call(db.execute, query)
+    yield from async_call(db.commit)
 
 
 @asyncio.coroutine
-def delete_all(async, db, network, user):
+def delete_all(async_call, db, network, user):
     query = table.delete() \
         .where(table.c.network == network.lower()) \
         .where(table.c.added_user == user.lower())
-    yield from async(db.execute, query)
-    yield from async(db.commit)
+    yield from async_call(db.execute, query)
+    yield from async_call(db.commit)
 
 
 @asyncio.coroutine
-def add_reminder(async, db, network, added_user, added_chan, message, remind_time, added_time):
+def add_reminder(async_call, db, network, added_user, added_chan, message, remind_time, added_time):
     query = table.insert().values(
         network=network.lower(),
         added_user=added_user.lower(),
@@ -68,17 +68,17 @@ def add_reminder(async, db, network, added_user, added_chan, message, remind_tim
         message=message,
         remind_time=remind_time
     )
-    yield from async(db.execute, query)
-    yield from async(db.commit)
+    yield from async_call(db.execute, query)
+    yield from async_call(db.commit)
 
 
 @asyncio.coroutine
 @hook.on_start()
-def load_cache(async, db):
+def load_cache(async_call, db):
     global reminder_cache
     reminder_cache = []
 
-    for network, remind_time, added_time, user, message in (yield from async(_load_cache_db, db)):
+    for network, remind_time, added_time, user, message in (yield from async_call(_load_cache_db, db)):
         reminder_cache.append((network, remind_time, added_time, user, message))
 
 
@@ -89,7 +89,7 @@ def _load_cache_db(db):
 
 @asyncio.coroutine
 @hook.periodic(30, initial_interval=30)
-def check_reminders(bot, async, db):
+def check_reminders(bot, async_call, db):
     current_time = datetime.now()
 
     for reminder in reminder_cache:
@@ -97,8 +97,8 @@ def check_reminders(bot, async, db):
         if remind_time <= current_time:
             if network not in bot.connections:
                 # connection is invalid
-                yield from add_reminder(async, db, network, remind_time, user)
-                yield from load_cache(async, db)
+                yield from add_reminder(async_call, db, network, remind_time, user)
+                yield from load_cache(async_call, db)
                 continue
 
             conn = bot.connections[network]
@@ -119,13 +119,13 @@ def check_reminders(bot, async, db):
                        " it seems I was unable to deliver it on time)".format(late_time)
                 conn.message(user, colors.parse(late))
 
-            yield from delete_reminder(async, db, network, remind_time, user)
-            yield from load_cache(async, db)
+            yield from delete_reminder(async_call, db, network, remind_time, user)
+            yield from load_cache(async_call, db)
 
 
 @asyncio.coroutine
 @hook.command('remind', 'reminder', 'in')
-def remind(text, nick, chan, db, conn, notice, async):
+def remind(text, nick, chan, db, conn, notice, async_call):
     """<1 minute, 30 seconds>: <do task> -- reminds you to <do task> in <1 minute, 30 seconds>"""
 
     count = len([x for x in reminder_cache if x[0] == conn.name and x[3] == nick.lower()])
@@ -134,8 +134,8 @@ def remind(text, nick, chan, db, conn, notice, async):
         if count == 0:
             return "You have no reminders to delete."
 
-        yield from delete_all(async, db, conn.name, nick)
-        yield from load_cache(async, db)
+        yield from delete_all(async_call, db, conn.name, nick)
+        yield from load_cache(async_call, db)
         return "Deleted all ({}) reminders for {}!".format(count, nick)
 
     # split the input on the first ":"
@@ -171,8 +171,8 @@ def remind(text, nick, chan, db, conn, notice, async):
         return "I can't remind you in the past!"
 
     # finally, add the reminder and send a confirmation message
-    yield from add_reminder(async, db, conn.name, nick, chan, message, remind_time, current_time)
-    yield from load_cache(async, db)
+    yield from add_reminder(async_call, db, conn.name, nick, chan, message, remind_time, current_time)
+    yield from load_cache(async_call, db)
 
     remind_text = format_time(seconds, count=2)
     output = "Alright, I'll remind you \"{}\" in $(b){}$(clear)!".format(message, remind_text)


### PR DESCRIPTION
- Wraps `asyncio.async()`/`asyncio.ensure_future()` in a util function for version compatibility
- Deprecates `Event.async()` in favor of `Event.async_call()` due to `async` and `await` becoming full keywords in 3.7.0
- Replace calls to `inspect.getargspec()` (deprecated in 3.0) with `inspect.signature()` (since 3.3) and `inspect.getfullargspec()`

Fixes #173 without sacrificing version compatibility