### PR TITLE
Add outgoing raw line hooks

### DIFF
--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -444,3 +444,12 @@ class IrcOutEvent(Event):
     @property
     def line(self):
         return str(self.irc_raw)
+
+
+class PostHookEvent(Event):
+    def __init__(self, *args, launched_hook=None, launched_event=None, result=None, error=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.launched_hook = launched_hook
+        self.launched_event = launched_event
+        self.result = result
+        self.error = error

--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -390,3 +390,9 @@ class CapEvent(Event):
         super().__init__(*args, **kwargs)
         self.cap = cap
         self.cap_param = cap_param
+
+
+class IrcOutEvent(Event):
+    @property
+    def line(self):
+        return self.irc_raw

--- a/cloudbot/hook.py
+++ b/cloudbot/hook.py
@@ -439,3 +439,19 @@ def on_connect(param=None, **kwargs):
 
 
 connect = on_connect
+
+
+def irc_out(param=None, **kwargs):
+    def _on_connect_hook(func):
+        hook = _get_hook(func, "irc_out")
+        if hook is None:
+            hook = _Hook(func, "irc_out")
+            _add_hook(func, hook)
+
+        hook._add_hook(kwargs)
+        return func
+
+    if callable(param):
+        return _on_connect_hook(param)
+    else:
+        return lambda func: _on_connect_hook(func)

--- a/cloudbot/hook.py
+++ b/cloudbot/hook.py
@@ -1,7 +1,6 @@
 import collections
 import inspect
 import re
-import collections
 from enum import Enum, unique, IntEnum
 
 from cloudbot.event import EventType
@@ -374,6 +373,7 @@ def on_stop(param=None, **kwargs):
     """External on_stop decorator. Can be used directly as a decorator, or with args to return a decorator
     :type param: function | None
     """
+
     def _on_stop_hook(func):
         hook = _get_hook(func, "on_stop")
         if hook is None:
@@ -381,10 +381,12 @@ def on_stop(param=None, **kwargs):
             _add_hook(func, hook)
         hook._add_hook(kwargs)
         return func
+
     if callable(param):
         return _on_stop_hook(param)
     else:
         return lambda func: _on_stop_hook(func)
+
 
 on_unload = on_stop
 
@@ -442,7 +444,7 @@ connect = on_connect
 
 
 def irc_out(param=None, **kwargs):
-    def _on_connect_hook(func):
+    def _decorate(func):
         hook = _get_hook(func, "irc_out")
         if hook is None:
             hook = _Hook(func, "irc_out")
@@ -452,6 +454,26 @@ def irc_out(param=None, **kwargs):
         return func
 
     if callable(param):
-        return _on_connect_hook(param)
+        return _decorate(param)
     else:
-        return lambda func: _on_connect_hook(func)
+        return lambda func: _decorate(func)
+
+
+def post_hook(param=None, **kwargs):
+    """
+    This hook will be fired just after a hook finishes executing
+    """
+
+    def _decorate(func):
+        hook = _get_hook(func, "post_hook")
+        if hook is None:
+            hook = _Hook(func, "post_hook")
+            _add_hook(func, hook)
+
+        hook._add_hook(kwargs)
+        return func
+
+    if callable(param):
+        return _decorate(param)
+    else:
+        return lambda func: _decorate(func)

--- a/cloudbot/util/parsers/irc.py
+++ b/cloudbot/util/parsers/irc.py
@@ -1,0 +1,305 @@
+"""
+Simple IRC line parser
+
+Backported from async-irc (https://github.com/snoonetIRC/async-irc.git)
+"""
+
+import re
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+
+TAGS_SENTINEL = '@'
+TAGS_SEP = ';'
+TAG_VALUE_SEP = '='
+
+PREFIX_SENTINEL = ':'
+PREFIX_USER_SEP = '!'
+PREFIX_HOST_SEP = '@'
+
+PARAM_SEP = ' '
+TRAIL_SENTINEL = ':'
+
+CAP_SEP = ' '
+CAP_VALUE_SEP = '='
+
+PREFIX_RE = re.compile(r':?(?P<nick>.+?)(?:!(?P<user>.+?))?(?:@(?P<host>.+?))?')
+
+TAG_VALUE_ESCAPES = {
+    '\\s': ' ',
+    '\\:': ';',
+    '\\r': '\r',
+    '\\n': '\n',
+    '\\\\': '\\',
+}
+
+TAG_VALUE_UNESCAPES = {
+    unescaped: escaped
+    for escaped, unescaped in TAG_VALUE_ESCAPES.items()
+}
+
+
+class Parseable(ABC):
+    """Abstract class for parseable objects"""
+
+    @abstractmethod
+    def __str__(self):
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def parse(text):
+        """Parse the object from a string"""
+        raise NotImplementedError
+
+
+class Cap(Parseable):
+    """Represents a CAP entity as defined in IRCv3.2"""
+
+    def __init__(self, name, value=None):
+        self.name = name
+        self.value = value or None
+
+    def __str__(self):
+        if self.value:
+            return CAP_VALUE_SEP.join((self.name, self.value))
+        return self.name
+
+    def __eq__(self, other):
+        if isinstance(other, Cap):
+            return self.name == other.name
+
+        return NotImplemented
+
+    @staticmethod
+    def parse(text: str):
+        """Parse a CAP entity from a string"""
+        name, _, value = text.partition(CAP_VALUE_SEP)
+        return Cap(name, value)
+
+
+class CapList(Parseable, list):
+    """Represents a list of CAP entities"""
+
+    def __str__(self):
+        return CAP_SEP.join(self)
+
+    @staticmethod
+    def parse(text):
+        """Parse a list of CAPs from a string"""
+        return CapList(map(Cap.parse, text.split(CAP_SEP)))
+
+
+class MessageTag(Parseable):
+    """
+    Basic class to wrap a message tag
+    """
+
+    def __init__(self, name, value=None):
+        self.name = name
+        self.value = value
+
+    @staticmethod
+    def unescape(value):
+        """
+        Replace the escaped characters in a tag value with their literals
+        :param value: Escaped string
+        :return: Unescaped string
+        """
+        new_value = ""
+        found = False
+        for i in range(len(value)):
+            if found:
+                found = False
+                continue
+
+            if value[i] == '\\':
+                if i + 1 >= len(value):
+                    raise ValueError("Unexpected end of string while parsing: {}".format(value))
+
+                new_value += TAG_VALUE_ESCAPES[value[i:i + 2]]
+                found = True
+            else:
+                new_value += value[i]
+
+        return new_value
+
+    @staticmethod
+    def escape(value):
+        """
+        Replace characters with their escaped variants
+        :param value: The raw string
+        :return: The escaped string
+        """
+        return "".join(TAG_VALUE_UNESCAPES.get(c, c) for c in value)
+
+    def __str__(self):
+        if self.value:
+            return "{}{}{}".format(
+                self.name, TAG_VALUE_SEP, self.escape(self.value)
+            )
+
+        return self.name
+
+    @staticmethod
+    def parse(text):
+        """
+        Parse a tag from a string
+        :param text: The basic tag string
+        :return: The MessageTag object
+        """
+        name, _, value = text.partition(TAG_VALUE_SEP)
+        if value:
+            value = MessageTag.unescape(value)
+
+        return MessageTag(name, value or None)
+
+
+class TagList(Parseable, OrderedDict):
+    """Object representing the list of message tags on a line"""
+
+    def __init__(self, tags) -> None:
+        super().__init__((tag.name, tag) for tag in tags)
+
+    def __str__(self):
+        return TAGS_SENTINEL + TAGS_SEP.join(map(str, self.values()))
+
+    @staticmethod
+    def parse(text):
+        """
+        Parse the list of tags from a string
+        :param text: The string to parse
+        :return: The parsed object
+        """
+        return TagList(
+            map(MessageTag.parse, filter(None, text.split(TAGS_SEP)))
+        )
+
+
+class Prefix(Parseable):
+    """
+    Object representing the prefix of a line
+    """
+
+    def __init__(self, nick, user=None, host=None):
+        self.nick = nick
+        self.user = user
+        self.host = host
+
+    @property
+    def mask(self):
+        """
+        The complete n!u@h mask
+        """
+        m = self.nick
+        if self.user:
+            m += PREFIX_USER_SEP + self.user
+
+        if self.host:
+            m += PREFIX_HOST_SEP + self.host
+
+        return m
+
+    def __str__(self):
+        if self:
+            return PREFIX_SENTINEL + self.mask
+
+        return ""
+
+    def __bool__(self):
+        return bool(self.nick)
+
+    @staticmethod
+    def parse(text):
+        """
+        Parse the prefix from a string
+        :param text: String to parse
+        :return: Parsed Object
+        """
+        if not text:
+            return Prefix('')
+
+        match = PREFIX_RE.fullmatch(text)
+        assert match, "Prefix did not match prefix pattern"
+        nick, user, host = match.groups()
+        return Prefix(nick, user, host)
+
+
+class ParamList(Parseable, list):
+    """
+    An object representing the parameter list from a line
+    """
+
+    def __init__(self, seq, has_trail=False):
+        super().__init__(seq)
+        self.has_trail = has_trail or (self and PARAM_SEP in self[-1])
+
+    def __str__(self):
+        if self.has_trail and self[-1][0] != TRAIL_SENTINEL:
+            return PARAM_SEP.join(self[:-1] + [TRAIL_SENTINEL + self[-1]])
+
+        return PARAM_SEP.join(self)
+
+    @staticmethod
+    def parse(text):
+        """
+        Parse a list of parameters
+        :param text: The list of parameters
+        :return: The parsed object
+        """
+        args = []
+        has_trail = False
+        while text:
+            if text[0] == TRAIL_SENTINEL:
+                args.append(text[1:])
+                has_trail = True
+                break
+
+            arg, _, text = text.partition(PARAM_SEP)
+            if arg:
+                args.append(arg)
+
+        return ParamList(args, has_trail=has_trail)
+
+
+class Message(Parseable):
+    """
+    An object representing a parsed IRC line
+    """
+
+    def __init__(self, tags=None, prefix=None, command=None, parameters=None):
+        self.tags = tags
+        self.prefix = prefix
+        self.command = command
+        self.parameters = parameters
+
+    @property
+    def parts(self):
+        """The parts that make up this message"""
+        return self.tags, self.prefix, self.command, self.parameters
+
+    def __str__(self):
+        return PARAM_SEP.join(map(str, filter(None, self.parts)))
+
+    def __bool__(self):
+        return any(self.parts)
+
+    @staticmethod
+    def parse(text):
+        """Parse an IRC message in to objects"""
+        if isinstance(text, bytes):
+            text = text.decode()
+
+        tags = ''
+        prefix = ''
+        if text.startswith(TAGS_SENTINEL):
+            tags, _, text = text.partition(PARAM_SEP)
+
+        if text.startswith(PREFIX_SENTINEL):
+            prefix, _, text = text.partition(PARAM_SEP)
+
+        command, _, params = text.partition(PARAM_SEP)
+        tags = TagList.parse(tags[1:])
+        prefix = Prefix.parse(prefix[1:])
+        command = command.upper()
+        params = ParamList.parse(params)
+        return Message(tags, prefix, command, params)

--- a/plugins/core_hooks.py
+++ b/plugins/core_hooks.py
@@ -1,0 +1,21 @@
+from cloudbot import hook
+from cloudbot.hook import Priority
+
+
+@hook.sieve(priority=Priority.LOWEST)
+def cmd_autohelp(bot, event, _hook):
+    if _hook.type == "command" and _hook.auto_help and not event.text and _hook.doc is not None:
+        event.notice_doc()
+        return None
+
+    return event
+
+
+@hook.post_hook(priority=Priority.LOWEST)
+def do_reply(result, error, launched_event):
+    if error is None and result is not None:
+        if isinstance(result, (list, tuple)):
+            # if there are multiple items in the response, return them on multiple lines
+            launched_event.reply(*result)
+        else:
+            launched_event.reply(*str(result).split('\n'))

--- a/plugins/core_out.py
+++ b/plugins/core_out.py
@@ -1,0 +1,43 @@
+"""
+Core filters for IRC raw lines
+"""
+
+from cloudbot import hook
+from cloudbot.hook import Priority
+
+NEW_LINE_TRANS_TBL = str.maketrans({
+    '\r': None,
+    '\n': None,
+    '\0': None,
+})
+
+
+@hook.irc_out(priority=Priority.HIGHEST)
+def strip_newlines(line, conn):
+    """
+    Removes newline characters from a message
+    :param line: str
+    :param conn: cloudbot.clients.irc.IrcClient
+    :return: str
+    """
+    do_strip = conn.config.get("strip_newlines", True)
+    if do_strip:
+        return line.translate(NEW_LINE_TRANS_TBL)
+    else:
+        return line
+
+
+@hook.irc_out(priority=Priority.HIGH)
+def truncate_line(line, conn):
+    line_len = conn.config.get("max_line_length", 510)
+    return line[:line_len] + "\r\n"
+
+
+@hook.irc_out(priority=Priority.LOWEST)
+def encode_line(line, conn):
+    if not isinstance(line, str):
+        return line
+
+    encoding = conn.config.get("encoding", "utf-8")
+    errors = conn.config.get("encoding_errors", "replace")
+    return line.encode(encoding, errors)

--- a/plugins/core_out.py
+++ b/plugins/core_out.py
@@ -4,6 +4,7 @@ Core filters for IRC raw lines
 
 from cloudbot import hook
 from cloudbot.hook import Priority
+from cloudbot.util import colors
 
 NEW_LINE_TRANS_TBL = str.maketrans({
     '\r': None,
@@ -41,3 +42,15 @@ def encode_line(line, conn):
     encoding = conn.config.get("encoding", "utf-8")
     errors = conn.config.get("encoding_errors", "replace")
     return line.encode(encoding, errors)
+
+
+@hook.irc_out(priority=Priority.HIGH)
+def strip_command_chars(parsed_line, conn, line):
+    chars = conn.config.get("strip_cmd_chars", "!.@;$")
+    if chars and parsed_line and parsed_line.command == "PRIVMSG" and parsed_line.parameters[-1][0] in chars:
+        new_msg = colors.parse("$(red)[!!]$(clear) ") + parsed_line.parameters[-1]
+        parsed_line.parameters[-1] = new_msg
+        parsed_line.has_trail = True
+        return parsed_line
+
+    return line


### PR DESCRIPTION
### New Hook Type
Adds a new hook type `hook.irc_out` which allows a plugin to modify raw messages as they are sent out
The result of a `hook.irc_out` function is used to replace the original message. Returning an empty string or `None` will result in the data not being sent and no further hooks will be launched.

### New Plugin
Adds the `core_out.py` plugin which contains the core `hook.irc_out` hooks.
The plugin does the following:
- Strips any `\r` or `\n` characters from a message (Can be disabled in the config)
- Truncates the message to a configured length
- Encodes the message using configurable settings
- Prepends a fixed string to a message that starts with common bot command characters (configurable, can be disabled by setting to an empty list). This is to prevent any command that returns user input from accidentally triggering other bots.