### PR TITLE
Add global optout plugin

### DIFF
--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -334,6 +334,14 @@ class Event:
         return False
 
     @asyncio.coroutine
+    def check_permissions(self, *perms, notice=True):
+        for perm in perms:
+            if (yield from self.check_permission(perm, notice=notice)):
+                return True
+
+        return False
+
+    @asyncio.coroutine
     def async_call(self, func, *args, **kwargs):
         if self.db_executor is not None:
             executor = self.db_executor

--- a/cloudbot/event.py
+++ b/cloudbot/event.py
@@ -316,6 +316,24 @@ class Event:
         return self.conn.permissions.has_perm_mask(self.mask, permission, notice=notice)
 
     @asyncio.coroutine
+    def check_permission(self, permission, notice=True):
+        """ returns whether or not the current user has a given permission
+        :type permission: str
+        :type notice: bool
+        :rtype: bool
+        """
+        if self.has_permission(permission, notice=notice):
+            return True
+
+        for perm_hook in self.bot.plugin_manager.perm_hooks[permission]:
+            # noinspection PyTupleAssignmentBalance
+            ok, res = yield from self.bot.plugin_manager.internal_launch(perm_hook, self)
+            if ok and res:
+                return True
+
+        return False
+
+    @asyncio.coroutine
     def async_call(self, func, *args, **kwargs):
         if self.db_executor is not None:
             executor = self.db_executor

--- a/cloudbot/hook.py
+++ b/cloudbot/hook.py
@@ -491,8 +491,6 @@ def post_hook(param=None, **kwargs):
 
 def permission(*perms, **kwargs):
     def _perm_hook(func):
-        assert len(inspect.getfullargspec(func).args) == 3, \
-            "Permission hook has incorrect argument count. Needs params: bot, event, hook"
         hook = _get_hook(func, "perm_check")
         if hook is None:
             hook = _PermissionHook(func)

--- a/docs/user/optout.md
+++ b/docs/user/optout.md
@@ -1,0 +1,26 @@
+# Hook OptOuts
+
+- The `core.optout` plugin allows channels to enable/disable specific hooks matching a pattern.
+- Both the channel and hook parameters accept glob patterns.
+- OptOut checks are done in order from the most specific patterns to the most broad.
+
+### Disabling a hook
+`optout plugin.command_func disable`
+
+### Enabling a globally disabled hook
+`optout plugin.command_func enable`
+
+### Globally disabling a hook
+`optout #* plugin.command_func disable`
+
+## Examples
+#### Disabling all attack commands in a channel
+`optout attacks.* disable`
+
+#### Allowing `attacks.compliment` while still not allowing other attacks
+`optout attacks.* disable`
+
+`optout attacks.compliment enable`
+
+#### Globally disable the quote command
+`optout #* quote.quote disable`

--- a/plugins/chan_track.py
+++ b/plugins/chan_track.py
@@ -172,17 +172,16 @@ def dump_dict(data, indent=2, level=0, _objects=None):
 
 
 @hook.permission("chanop")
-def perm_check(bot, event, _hook):
-    chan = event.chan
+def perm_check(chan, conn, nick):
     if not chan:
         return False
 
-    chans = event.conn.memory["chan_data"]
+    chans = conn.memory["chan_data"]
     if chan not in chans:
         return False
 
     chan_data = chans[chan]
-    nick_cf = event.nick.casefold()
+    nick_cf = nick.casefold()
     if nick_cf not in chan_data["users"]:
         return False
 

--- a/plugins/core/core_sieve.py
+++ b/plugins/core/core_sieve.py
@@ -63,21 +63,8 @@ def sieve_suite(bot, event, _hook):
     if allowed_permissions:
         allowed = False
         for perm in allowed_permissions:
-            if event.has_permission(perm):
+            if (yield from event.check_permission(perm)):
                 allowed = True
-                break
-
-            for perm_hook in bot.plugin_manager.perm_hooks[perm]:
-                try:
-                    res = yield from async_util.run_func(event.loop, perm_hook.function, bot, event, _hook)
-                except Exception:
-                    logger.exception("Error in hook {}".format(perm_hook.description))
-                else:
-                    if res:
-                        allowed = True
-                        break
-
-            if allowed:
                 break
 
         if not allowed:

--- a/plugins/core/optout.py
+++ b/plugins/core/optout.py
@@ -1,0 +1,160 @@
+"""
+Bot wide hook opt-out for channels
+"""
+import asyncio
+from collections import defaultdict
+from fnmatch import fnmatch
+from functools import total_ordering
+from threading import RLock
+
+from sqlalchemy import Table, Column, String, Boolean, PrimaryKeyConstraint, and_
+
+from cloudbot import hook
+from cloudbot.hook import Priority
+from cloudbot.util import database, web
+
+optout_table = Table(
+    'optout',
+    database.metadata,
+    Column('network', String),
+    Column('chan', String),
+    Column('hook', String),
+    Column('allow', Boolean, default=False),
+    PrimaryKeyConstraint('network', 'chan', 'hook')
+)
+
+optout_cache = defaultdict(list)
+
+cache_lock = RLock()
+
+
+@total_ordering
+class OptOut:
+    def __init__(self, channel, hook_pattern, allow):
+        self.channel = channel.casefold()
+        self.hook = hook_pattern.casefold()
+        self.allow = allow
+
+    def __lt__(self, other):
+        if isinstance(other, OptOut):
+            diff = len(self.channel) - len(other.channel)
+            if diff:
+                return diff < 0
+
+            return len(self.hook) < len(other.hook)
+
+        return NotImplemented
+
+    def __str__(self):
+        return "{} {} {}".format(self.channel, self.hook, self.allow)
+
+    def match(self, channel, hook_name):
+        return fnmatch(channel.casefold(), self.channel) and fnmatch(hook_name.casefold(), self.hook)
+
+
+@hook.onload
+def load_cache(db):
+    with cache_lock:
+        optout_cache.clear()
+        for row in db.execute(optout_table.select()):
+            optout_cache[row["network"]].append(OptOut(row["chan"], row["hook"], row["allow"]))
+
+        for opts in optout_cache.values():
+            opts.sort(reverse=True)
+
+
+# noinspection PyUnusedLocal
+@hook.sieve(priority=Priority.HIGHEST)
+def optout_sieve(bot, event, _hook):
+    if not event.chan or not event.conn:
+        return event
+
+    hook_name = _hook.plugin.title + "." + _hook.function_name
+    with cache_lock:
+        optouts = optout_cache[event.conn.name]
+        for _optout in optouts:
+            if _optout.match(event.chan, hook_name):
+                return event if _optout.allow else None
+
+    return event
+
+
+_STR_TO_BOOL = {
+    "yes": True,
+    "y": True,
+    "no": False,
+    "n": False,
+    "on": True,
+    "off": False,
+    "enable": True,
+    "disable": False,
+    "allow": True,
+    "deny": False,
+}
+
+
+def set_optout(db, conn, chan, pattern, allowed):
+    conn_cf = conn.casefold()
+    chan_cf = chan.casefold()
+    pattern_cf = pattern.casefold()
+    clause = and_(optout_table.c.network == conn_cf, optout_table.c.chan == chan_cf, optout_table.c.hook == pattern_cf)
+    res = db.execute(optout_table.update().values(allow=allowed).where(clause))
+    if not res.rowcount:
+        db.execute(optout_table.insert().values(network=conn_cf, chan=chan_cf, hook=pattern_cf, allow=allowed))
+
+    db.commit()
+    load_cache(db)
+
+
+@asyncio.coroutine
+@hook.command
+def optout(text, event, db, conn):
+    """[chan] <pattern> [allow] - Set the global allow option for hooks matching <pattern> in [chan], or the current channel if not specified
+    :type text: str
+    :type event: cloudbot.event.CommandEvent
+    """
+    args = text.split()
+    old_chan = event.chan
+    if args[0].startswith("#") and len(args) > 1:
+        event.chan = args.pop(0)
+
+    chan = event.chan
+
+    has_perm = False
+    for perm in ("chanop", "snoonetstaff", "botcontrol"):
+        if (yield from event.check_permission(perm)):
+            has_perm = True
+            break
+
+    event.chan = old_chan
+
+    if not has_perm:
+        event.notice("Sorry, you may not configure optout settings for that channel.")
+        return
+
+    pattern = args.pop(0)
+
+    allowed = False
+    if args:
+        allow = args.pop(0)
+        try:
+            allowed = _STR_TO_BOOL[allow.lower()]
+        except KeyError:
+            return "Invalid allow option."
+
+    yield from event.async_call(set_optout, db, conn.name, chan, pattern, allowed)
+
+    return "{action} hooks matching {pattern} in {channel}.".format(
+        action="Enabled" if allowed else "Disabled",
+        pattern=pattern,
+        channel=chan
+    )
+
+
+@hook.command("dumpoptout", permissions=["botcontrol"], autohelp=False)
+def dump_optout(conn):
+    """- Dump the optout table to a pastebin"""
+    with cache_lock:
+        out = '\n'.join(map(str, optout_cache[conn.name]))
+
+    return web.paste(out)

--- a/plugins/core/optout.py
+++ b/plugins/core/optout.py
@@ -60,18 +60,11 @@ class OptOut:
 
 
 @asyncio.coroutine
-def check_permissions(event, *perms):
-    for perm in perms:
-        if (yield from event.check_permission(perm)):
-            return True
-
-
-@asyncio.coroutine
 def check_channel_permissions(event, chan, *perms):
     old_chan = event.chan
     event.chan = chan
 
-    allowed = yield from check_permissions(event, *perms)
+    allowed = yield from event.check_permissions(*perms)
 
     event.chan = old_chan
     return allowed
@@ -220,7 +213,7 @@ def check_global_perms(event):
     if text:
         chan = text.split()[0]
 
-    can_global = yield from check_permissions(event, "snoonetstaff", "botcontrol")
+    can_global = yield from event.check_permissions("snoonetstaff", "botcontrol")
     allowed = can_global or (yield from check_channel_permissions(event, chan, "op", "chanop"))
 
     if not allowed:

--- a/plugins/core/optout.py
+++ b/plugins/core/optout.py
@@ -74,7 +74,11 @@ def optout_sieve(bot, event, _hook):
         optouts = optout_cache[event.conn.name]
         for _optout in optouts:
             if _optout.match(event.chan, hook_name):
-                return event if _optout.allow else None
+                if not _optout.allow:
+                    if _hook.type == "command":
+                        event.notice("Sorry, that command is disabled in this channel.")
+                    return None
+                return event
 
     return event
 

--- a/plugins/core/optout.py
+++ b/plugins/core/optout.py
@@ -239,7 +239,7 @@ def check_global_perms(event):
 @asyncio.coroutine
 @hook.command("listoptout", autohelp=False)
 def list_optout(conn, event, async_call):
-    """[channel] - View the global optout data for <channel> or the current channel if not specified
+    """[channel] - View the opt out data for <channel> or the current channel if not specified. Specify "global" to view all data for this network
     :type conn: cloudbot.clients.irc.Client
     :type chan: str
     :type text: str
@@ -256,7 +256,7 @@ def list_optout(conn, event, async_call):
 @asyncio.coroutine
 @hook.command("clearoptout", autohelp=False)
 def clear(conn, event, db, async_call):
-    """[channel] - Clears the optout list for a channel"""
+    """[channel] - Clears the optout list for a channel. Specify "global" to clear all data for this network"""
     chan, allowed = yield from check_global_perms(event)
 
     count = yield from async_call(clear_optout, db, conn.name, chan)


### PR DESCRIPTION
This plugin allows certain hooks/commands to be disabled/enabled per channel. Channels can be specified as glob patterns (eg `#*` to match all channels), allowing certain hooks to be disabled in a wide range of channels and only re-enabled in certain channels.