### PR TITLE
Fix import order in __main__

### DIFF
--- a/cloudbot/__main__.py
+++ b/cloudbot/__main__.py
@@ -1,14 +1,10 @@
-import asyncio
 import logging
 import os
+import signal
 import sys
 import time
-import signal
-
 # store the original working directory, for use when restarting
 from functools import partial
-
-from cloudbot.util import async_util
 
 original_wd = os.path.realpath(".")
 
@@ -21,6 +17,7 @@ os.chdir(path0)
 
 # import bot
 from cloudbot.bot import CloudBot
+from cloudbot.util import async_util
 
 
 def main():


### PR DESCRIPTION
This fixes a bug where if the run directory for the bot changes during runtime, it will error on restart when attempting to re-import `async_util`