### PR TITLE
Updated whois plugin, fixed crash when certain registrar data is NoneType

### DIFF
--- a/plugins/whois.py
+++ b/plugins/whois.py
@@ -31,14 +31,33 @@ def whois(text, reply):
     info = []
 
     # We suppress errors here because different domains provide different data fields
-    with suppress(KeyError):
+    try:
         info.append(("Registrar", data["registrar"][0]))
+    except KeyError:
+        info.append(("Registrar", 'Not Found'))
+    except TypeError:
+        info.append(("Registrar", 'Not Found'))
 
-    with suppress(KeyError):
+    try:
+        info.append(("Registrant", data["contacts"]["registrant"]["name"]))
+    except KeyError:
+        info.append(("Registrant", 'Not Found'))
+    except TypeError:
+        info.append(("Registrant", 'Not Found'))
+
+    try:
         info.append(("Registered", data["creation_date"][0].strftime("%d-%m-%Y")))
+    except KeyError:
+        info.append(("Registered", 'Not Found'))
+    except TypeError:
+        info.append(("Registered", 'Not Found'))
 
-    with suppress(KeyError):
+    try:
         info.append(("Expires", data["expiration_date"][0].strftime("%d-%m-%Y")))
+    except KeyError:
+        info.append(("Expires", 'Not Found'))
+    except TypeError:
+        info.append(("Expires", 'Not Found'))
 
     if not info:
         return "No information returned."


### PR DESCRIPTION
This patch fixes the following traceback
```
Traceback (most recent call last):
File "/opt/CloudBot/cloudbot/plugin.py", line 456, in internal_launch
out = yield from task
File "/usr/lib64/python3.4/asyncio/futures.py", line 358, in __iter__
yield self  # This tells Task to wait for completion.
File "/usr/lib64/python3.4/asyncio/tasks.py", line 297, in _wakeup
future.result()
File "/usr/lib64/python3.4/asyncio/futures.py", line 274, in result
raise self._exception
File "/usr/lib64/python3.4/concurrent/futures/thread.py", line 54, in run
result = self.fn(*self.args, **self.kwargs)
File "/opt/CloudBot/cloudbot/plugin.py", line 423, in _execute_hook_threaded
return call_with_args(hook.function, event)
File "/opt/CloudBot/cloudbot/util/func_utils.py", line 19, in call_with_args
return func(*args)
File "/opt/CloudBot/plugins/whois.py", line 38, in whois
except TypeError:
TypeError: 'NoneType' object is not subscriptable
```